### PR TITLE
Change Request.get_more/5 to use responses "next" key as next `request_path` in recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ project = ExJira.Project.get!("1001", expand: "description,url")
 {:ok, issues} = ExJira.Project.get_issues("1001", expand: "operations")
 issues = ExJira.Project.get_issues!("1001")
 issues = ExJira.Project.get_issues!("1001", expand: "operations")
-
-{:ok, issues} = ExJira.Project.get_issues("1001")
-{:ok, issues} = ExJira.Project.get_issues("1001", expand: "operations")
-issues = ExJira.Project.get_issues!("1001")
-issues = ExJira.Project.get_issues!("1001", expand: "operations")
 ```
 Raw requests to Jira for resources that are not yet implemented can be made like this:
 

--- a/lib/ex_jira/dashboard.ex
+++ b/lib/ex_jira/dashboard.ex
@@ -17,7 +17,7 @@ defmodule ExJira.Dashboard do
       {:ok, [%{"id" => "1007"}, %{"id" => "1008"}]}
 
   """
-  @spec all([{atom, String.t}]) :: Request.request_response
+  @spec all([{atom, String.t()}]) :: Request.request_response()
   def all(query_params \\ []) do
     Request.get_all("/dashboard", "dashboards", QueryParams.convert(query_params, @all_params))
   end
@@ -31,11 +31,11 @@ defmodule ExJira.Dashboard do
       [%{"id" => "1007"}, %{"id" => "1008"}]
 
   """
-  @spec all!([{atom, String.t}]) :: [any]
+  @spec all!([{atom, String.t()}]) :: [any]
   def all!(query_params \\ []) do
     case all(query_params) do
       {:ok, items} -> items
-      {:error, reason} -> raise "Error in #{__MODULE__}.all!: #{inspect reason}"
+      {:error, reason} -> raise "Error in #{__MODULE__}.all!: #{inspect(reason)}"
     end
   end
 
@@ -48,7 +48,7 @@ defmodule ExJira.Dashboard do
       {:ok, %{"id" => "1009"}}
 
   """
-  @spec get(String.t) :: Request.request_response
+  @spec get(String.t()) :: Request.request_response()
   def get(id) do
     Request.get_one("/dashboard/#{id}", "")
   end
@@ -62,12 +62,11 @@ defmodule ExJira.Dashboard do
       %{"id" => "1009"}
 
   """
-  @spec get!(String.t) :: any
+  @spec get!(String.t()) :: any
   def get!(id) do
     case get(id) do
       {:ok, item} -> item
-      {:error, reason} -> raise "Error in #{__MODULE__}.get!: #{inspect reason}"
+      {:error, reason} -> raise "Error in #{__MODULE__}.get!: #{inspect(reason)}"
     end
   end
-
 end

--- a/lib/ex_jira/utils/mock_client.ex
+++ b/lib/ex_jira/utils/mock_client.ex
@@ -5,18 +5,28 @@ defmodule ExJira.MockClient do
 
   @headers %HTTPotion.Headers{hdrs: %{"content-type" => "application/json;charset=UTF-8"}}
 
-  #Request
+  # Request
   def get("https://test_account/rest/api/latest/headers/test?a=b&c=d",
-          [timeout: 30000,
-           headers: ["Content-Type": "application/json",
-                     Authorization: "Basic dGVzdF91c2VybmFtZTp0ZXN0X3Bhc3N3b3Jk"]]) do
+        timeout: 30000,
+        headers: [
+          "Content-Type": "application/json",
+          Authorization: "Basic dGVzdF91c2VybmFtZTp0ZXN0X3Bhc3N3b3Jk"
+        ]
+      ) do
     %HTTPotion.Response{body: "{\"id\":\"1000\"}", headers: @headers}
   end
+
   def get("https://test_account/rest/api/latest/headers/test2?a=b&c=d",
-          [timeout: 30000,
-           headers: ["Content-Type": "application/json",
-                     Authorization: "Basic dGVzdF91c2VybmFtZTp0ZXN0X3Bhc3N3b3Jk"]]) do
-    %HTTPotion.Response{body: "{\"total\":2, \"things\":[{\"id\":\"1004\"},{\"id\":\"1005\"}]}", headers: @headers}
+        timeout: 30000,
+        headers: [
+          "Content-Type": "application/json",
+          Authorization: "Basic dGVzdF91c2VybmFtZTp0ZXN0X3Bhc3N3b3Jk"
+        ]
+      ) do
+    %HTTPotion.Response{
+      body: "{\"total\":2, \"things\":[{\"id\":\"1004\"},{\"id\":\"1005\"}]}",
+      headers: @headers
+    }
   end
 
   def get("https://test_account/rest/api/latest/some/item?a=b&c=d", _) do
@@ -28,7 +38,10 @@ defmodule ExJira.MockClient do
   end
 
   def get("https://test_account/rest/api/latest/some/items?a=b&c=d", _) do
-    %HTTPotion.Response{body: "{\"total\":2, \"items\":[{\"id\":\"1002\"},{\"id\":\"1003\"}]}", headers: @headers}
+    %HTTPotion.Response{
+      body: "{\"total\":2, \"items\":[{\"id\":\"1002\"},{\"id\":\"1003\"}]}",
+      headers: @headers
+    }
   end
 
   def get("https://test_account/rest/api/latest/some/failure?a=b&c=d", _) do
@@ -39,23 +52,26 @@ defmodule ExJira.MockClient do
     %HTTPotion.Response{body: "{\"id\":\"1006\"}", headers: @headers}
   end
 
-  #Dashboard
+  # Dashboard
 
-  def get("https://test_account/rest/api/latest/dashboard?", _) do
-    %HTTPotion.Response{body: "{\"total\":2, \"dashboards\":[{\"id\":\"1007\"},{\"id\":\"1008\"}]}", headers: @headers}
+  def get("https://test_account/rest/api/latest/dashboard", _) do
+    %HTTPotion.Response{
+      body: "{\"total\":2, \"dashboards\":[{\"id\":\"1007\"},{\"id\":\"1008\"}]}",
+      headers: @headers
+    }
   end
 
-  def get("https://test_account/rest/api/latest/dashboard/1009?", _) do
+  def get("https://test_account/rest/api/latest/dashboard/1009", _) do
     %HTTPotion.Response{body: "{\"id\":\"1009\"}", headers: @headers}
   end
 
-  #Project
+  # Project
 
-  def get("https://test_account/rest/api/latest/project?", _) do
+  def get("https://test_account/rest/api/latest/project", _) do
     %HTTPotion.Response{body: "[{\"id\":\"1010\"},{\"id\":\"1011\"}]", headers: @headers}
   end
 
-  def get("https://test_account/rest/api/latest/issue/ISSUE-1012?", _) do
+  def get("https://test_account/rest/api/latest/issue/ISSUE-1012", _) do
     %HTTPotion.Response{body: "{\"id\":\"1012\"}", headers: @headers}
   end
 
@@ -63,7 +79,7 @@ defmodule ExJira.MockClient do
     %HTTPotion.Response{body: "{\"id\":\"1012\"}", headers: @headers}
   end
 
-  def get("https://test_account/rest/api/latest/project/1012?", _) do
+  def get("https://test_account/rest/api/latest/project/1012", _) do
     %HTTPotion.Response{body: "{\"id\":\"1012\"}", headers: @headers}
   end
 
@@ -72,11 +88,16 @@ defmodule ExJira.MockClient do
   end
 
   def get("https://test_account/rest/api/latest/search?jql=project=1013", _) do
-    %HTTPotion.Response{body: "{\"total\":2, \"issues\":[{\"id\":\"100040\"}, {\"id\":\"100041\"}]}", headers: @headers}
+    %HTTPotion.Response{
+      body: "{\"total\":2, \"issues\":[{\"id\":\"100040\"}, {\"id\":\"100041\"}]}",
+      headers: @headers
+    }
   end
 
   def get("https://test_account/rest/api/latest/search?expand=operations&jql=project=1013", _) do
-    %HTTPotion.Response{body: "{\"total\":2, \"issues\":[{\"id\":\"100040\"}, {\"id\":\"100041\"}]}", headers: @headers}
+    %HTTPotion.Response{
+      body: "{\"total\":2, \"issues\":[{\"id\":\"100040\"}, {\"id\":\"100041\"}]}",
+      headers: @headers
+    }
   end
-
 end

--- a/lib/ex_jira/utils/query_params.ex
+++ b/lib/ex_jira/utils/query_params.ex
@@ -1,5 +1,4 @@
 defmodule ExJira.QueryParams do
-
   @moduledoc """
   Helper module to convert parameters passed as a keyword list into a querystring.
   """
@@ -26,17 +25,19 @@ defmodule ExJira.QueryParams do
       ""
 
   """
-  @spec convert([{atom, String.t}], [atom]) :: String.t
+  @spec convert([{atom, String.t()}], [atom]) :: String.t()
   def convert(_params, []), do: ""
+
   def convert(params, [h | t]) do
-    amp = case t do
-      [] -> ""
-      _  -> "&"
-    end
+    amp =
+      case t do
+        [] -> ""
+        _ -> "&"
+      end
+
     cond do
       Keyword.has_key?(params, h) -> "#{to_string(h)}=#{params[h]}#{amp}#{convert(params, t)}"
       true -> convert(params, t)
     end
   end
-
 end


### PR DESCRIPTION
This addresses an issue that I ran into here: https://github.com/TheFirstAvenger/elixir-ex_jira/issues/3

---
I wanted to open first by saying **thank you** for creating this project. If any stylistic things in this PR are not to your liking I would be more than happy to adjust them. If you see something that I missed regarding these code changes and you have any suggestions for a refactor I encourage the corrective criticisms.

Obviously, this is totally your project and I have no intention of stepping on your toes. I have always believed that with Open-Source if you find something in a pkg you are using its important to not only report it but provide a possible solution if you are able. I digress...

*\*Apologies in advance for the Elixir formatter changes adding extra diffs*

---

The changes essentially substitute an overloaded `Request.get_more/5` function, that matches on the responses `"next" =>` key, for the case statement that was being used

Since the response only has that key when there are more items to be fetched we can assume that if it isn't present the retrieved items have completed and are ready to be returned with the `Request.get_more/5` function that does not require the `"next" =>` key pattern.

In the process of this change I separated out the building of the url within the `Request.request/4` function so that it handled the case where no additional `query_params` are passed in and removes any trailing "&".

I also removed the trailing "?"'s from the `MockClient` since they are not required and with the `Request.build_request_url/1` change were causing failures.

All tests are passing and these changes resolve the issue I was seeing.